### PR TITLE
Datetime refactor

### DIFF
--- a/geodepy/constants.py
+++ b/geodepy/constants.py
@@ -6,6 +6,7 @@ Constants Module
 """
 
 from math import sqrt
+from datetime import date
 
 c_vac = 299792.458
 k_0 = 0.9996
@@ -52,7 +53,7 @@ class Transformation(object):
                  d_tx=0.0, d_ty=0.0, d_tz=0.0, d_sc=0.0, d_rx=0.0, d_ry=0.0, d_rz=0.0):
         self.from_datum = from_datum    # Datum Transforming From
         self.to_datum = to_datum        # Datum Transforming To
-        self.ref_epoch = ref_epoch      # Reference Epoch (YYYY.DOY)
+        self.ref_epoch = ref_epoch      # Reference Epoch (datetime.date Object)
         self.tx = tx                    # Translation in x (m)
         self.ty = ty                    # Translation in y (m)
         self.tz = tz                    # Translation in z (m)
@@ -98,22 +99,23 @@ class Transformation(object):
 
     def __add__(self, other):
         """
-        Change Reference Epoch (add decimal year).
+        Change Transformation Epoch to a specified date.
         Advances all transformation parameters by their respective rates of change.
-        :param other: Decimal Year
-        :return: Transformation object with parameters and ref epoch advanced by input year
+        :param other: datetime.date Object
+        :return: Transformation object with parameters and ref epoch moved to specified date
         """
-        if type(other) == int or type(other) == float:
+        if type(other) == date:
+            timediff = (other - self.ref_epoch).days/365.25
             return Transformation(self.to_datum,
                                   self.from_datum,
-                                  self.ref_epoch + other,
-                                  round(self.tx + (self.d_tx * other), 8),
-                                  round(self.ty + (self.d_ty * other), 8),
-                                  round(self.tz + (self.d_tz * other), 8),
-                                  round(self.sc + (self.d_sc * other), 8),
-                                  round(self.rx + (self.d_rx * other), 8),
-                                  round(self.ry + (self.d_ry * other), 8),
-                                  round(self.rz + (self.d_rz * other), 8),
+                                  other,
+                                  round(self.tx + (self.d_tx * timediff), 8),
+                                  round(self.ty + (self.d_ty * timediff), 8),
+                                  round(self.tz + (self.d_tz * timediff), 8),
+                                  round(self.sc + (self.d_sc * timediff), 8),
+                                  round(self.rx + (self.d_rx * timediff), 8),
+                                  round(self.ry + (self.d_ry * timediff), 8),
+                                  round(self.rz + (self.d_rz * timediff), 8),
                                   self.d_tx,
                                   self.d_ty,
                                   self.d_tz,
@@ -121,52 +123,8 @@ class Transformation(object):
                                   self.d_rx,
                                   self.d_ry,
                                   self.d_rz)
-        """ Experimental - Not Yet Functional
-        elif type(other) == Transformation:
-            epoch_diff = other.ref_epoch - self.ref_epoch
-            return Transformation(other.to_datum,
-                                  self.from_datum,
-                                  self.ref_epoch,
-                                  round(self.tx + (other.tx * epoch_diff), 8),
-                                  round(self.ty + (other.ty * epoch_diff), 8),
-                                  round(self.tz + (other.tz * epoch_diff), 8),
-                                  round(self.sc + (other.sc * epoch_diff), 8),
-                                  round(self.rx + (other.rx * epoch_diff), 8),
-                                  round(self.ry + (other.ry * epoch_diff), 8),
-                                  round(self.rz + (other.rz * epoch_diff), 8),
-                                  round(self.d_tx + (other.d_tx * epoch_diff), 8),
-                                  round(self.d_ty + (other.d_ty * epoch_diff), 8),
-                                  round(self.d_tz + (other.d_tz * epoch_diff), 8),
-                                  round(self.d_sc + (other.d_sc * epoch_diff), 8),
-                                  round(self.d_rx + (other.d_rx * epoch_diff), 8),
-                                  round(self.d_ry + (other.d_ry * epoch_diff), 8),
-                                  round(self.d_rz + (other.d_rz * epoch_diff), 8))
-            """
-
-    def __sub__(self, other):
-        """
-        Change Reference Epoch (subtract decimal year).
-        Retracts all transformation parameters by their respective rates of change.
-        :param other: Decimal Year
-        :return: Transformation object with parameters and ref epoch advanced by input year
-        """
-        return Transformation(self.to_datum,
-                              self.from_datum,
-                              self.ref_epoch - other,
-                              round(self.tx - (self.d_tx * other), 8),
-                              round(self.ty - (self.d_ty * other), 8),
-                              round(self.tz - (self.d_tz * other), 8),
-                              round(self.sc - (self.d_sc * other), 8),
-                              round(self.rx - (self.d_rx * other), 8),
-                              round(self.ry - (self.d_ry * other), 8),
-                              round(self.rz - (self.d_rz * other), 8),
-                              self.d_tx,
-                              self.d_ty,
-                              self.d_tz,
-                              self.d_sc,
-                              self.d_rx,
-                              self.d_ry,
-                              self.d_rz)
+        else:
+            ValueError('supports adding datetime.date objects only')
 
 
 def iers2trans(itrf_from, itrf_to, ref_epoch, tx, ty, tz, sc, rx, ry, rz, d_tx, d_ty, d_tz, d_sc, d_rx, d_ry, d_rz):
@@ -200,13 +158,12 @@ def iers2trans(itrf_from, itrf_to, ref_epoch, tx, ty, tz, sc, rx, ry, rz, d_tx, 
                           round(d_sc / 1000, 8),
                           round(-d_rx / 1000, 8), round(-d_ry / 1000, 8), round(-d_rz / 1000, 8))
 
-
 # GDA1994 to GDA2020 Transformation Parameters from GDA2020 Tech Manual v1.1.1
 
 gda94to20 = Transformation('GDA1994', 'GDA2020', 0,
                            0.06155, -0.01087, -0.04019, -0.009994, -0.0394924, -0.0327221, -0.0328979)
 
-itrf14togda20 = Transformation('ITRF2014', 'GDA2020', 2020,
+itrf14togda20 = Transformation('ITRF2014', 'GDA2020', date(2020, 1, 1),
                                0, 0, 0, 0, 0, 0, 0,
                                0, 0, 0, 0, 0.00150379, 0.00118346, 0.00120716)
 
@@ -214,23 +171,23 @@ itrf14togda20 = Transformation('ITRF2014', 'GDA2020', 2020,
 # AGD66 and AGD84 to GDA94 Transformation Parameters from GDA94 Tech Manual v2.4
 # link: http://www.icsm.gov.au/datum/gda2020-and-gda94-technical-manuals
 
-itrf08togda94 = Transformation('ITRF2008', 'GDA1994', 1994.0,
+itrf08togda94 = Transformation('ITRF2008', 'GDA1994', date(1994, 1, 1),
                                -0.08468, -0.01942, 0.03201, 0.00971, -0.0004254, 0.0022578, 0.0024015,
                                0.00142, 0.00134, 0.00090, 0.000109, 0.0015461, 0.001820, 0.0011551)
 
-itrf05togda94 = Transformation('ITRF2005', 'GDA1994', 1994.0,
+itrf05togda94 = Transformation('ITRF2005', 'GDA1994', date(1994, 1, 1),
                                -0.07973, -0.00686, 0.03803, 0.006636, -0.0000351, 0.0021211, 0.0021411,
                                0.00225, -0.00062, -0.00056, 0.000294, 0.0014707, 0.0011443, 0.0011701)
 
-itrf00togda94 = Transformation('ITRF2000', 'GDA1994', 1994.0,
+itrf00togda94 = Transformation('ITRF2000', 'GDA1994', date(1994, 1, 1),
                                -0.04591, -0.02985, -0.02037, 0.00707, -0.0016705, 0.0004594, 0.0019356,
                                -0.00466, 0.00355, 0.01124, 0.000249, 0.0017454, 0.0014868, 0.001224)
 
-itrf97togda94 = Transformation('ITRF1997', 'GDA1994', 1994.0,
+itrf97togda94 = Transformation('ITRF1997', 'GDA1994', date(1994, 1, 1),
                                -0.01463, -0.02762, -0.02532, 0.006695, -0.0017893, -0.0006047, 0.0009962,
                                -0.00860, 0.00036, 0.01125, 0.000007, 0.0016394, 0.0015198, 0.0013801)
 
-itrf96togda94 = Transformation('ITRF1996', 'GDA1994', 1994.0,
+itrf96togda94 = Transformation('ITRF1996', 'GDA1994', date(1994, 1, 1),
                                0.02454, -0.03643, -0.06812, 0.006901, -0.0027359, -0.0020431, 0.0003731,
                                -0.02180, 0.00471, 0.02627, 0.000388, 0.0020203, 0.0021735, 0.0016290)
 
@@ -256,105 +213,105 @@ agd66togda94_nt = Transformation('AGD66', 'GDA94', 0,
 # ITRF2014 Parameters
 # link: http://itrf.ign.fr/doc_ITRF/Transfo-ITRF2014_ITRFs.txt
 
-itrf14to08 = iers2trans('ITRF2014', 'ITRF2008', 2010.0,
+itrf14to08 = iers2trans('ITRF2014', 'ITRF2008', date(2010, 1, 1),
                         1.6, 1.9, 2.4, -0.02, 0, 0, 0,
                         0.0, 0.0, -0.1, 0.03, 0, 0, 0)
 
-itrf14to05 = iers2trans('ITRF2014', 'ITRF2005', 2010.0,
+itrf14to05 = iers2trans('ITRF2014', 'ITRF2005', date(2010, 1, 1),
                         2.6, 1.0, -2.3, 0.92, 0, 0, 0,
                         0.3, 0.0, -0.1, 0.03, 0, 0, 0)
 
-itrf14to00 = iers2trans('ITRF2014', 'ITRF2000', 2010.0,
+itrf14to00 = iers2trans('ITRF2014', 'ITRF2000', date(2010, 1, 1),
                         0.7, 1.2, -26.1, 2.12, 0, 0, 0,
                         0.1, 0.1, -1.9, 0.11, 0, 0, 0)
 
-itrf14to97 = iers2trans('ITRF2014', 'ITRF1997', 2010.0,
+itrf14to97 = iers2trans('ITRF2014', 'ITRF1997', date(2010, 1, 1),
                         7.4, -0.5, -62.8, 3.80, 0, 0, 0.26,
                         0.1, -0.5, -3.3, 0.12, 0, 0, 0.02)
 
-itrf14to96 = iers2trans('ITRF2014', 'ITRF1996', 2010.0,
+itrf14to96 = iers2trans('ITRF2014', 'ITRF1996', date(2010, 1, 1),
                         7.4, -0.5, -62.8, 3.80, 0, 0, 0.26,
                         0.1, -0.5, -3.3, 0.12, 0, 0, 0.02)
 
-itrf14to94 = iers2trans('ITRF2014', 'ITRF1994', 2010.0,
+itrf14to94 = iers2trans('ITRF2014', 'ITRF1994', date(2010, 1, 1),
                         7.4, -0.5, -62.8, 3.80, 0, 0, 0.26,
                         0.1, -0.5, -3.3, 0.12, 0, 0, 0.02)
 
-itrf14to93 = iers2trans('ITRF2014', 'ITRF1993', 2010.0,
+itrf14to93 = iers2trans('ITRF2014', 'ITRF1993', date(2010, 1, 1),
                         -50.4, 3.3, -60.2, 4.29, -2.81, -3.38, 0.40,
                         -2.8, -0.1, -2.5, 0.12, -0.11, -0.19, 0.07)
 
-itrf14to92 = iers2trans('ITRF2014', 'ITRF1992', 2010.0,
+itrf14to92 = iers2trans('ITRF2014', 'ITRF1992', date(2010, 1, 1),
                         15.4, 1.5, -70.8, 3.09, 0, 0, 0.26,
                         0.1, -0.5, -3.3, 0.12, 0, 0, 0.02)
 
-itrf14to91 = iers2trans('ITRF2014', 'ITRF1991', 2010.0,
+itrf14to91 = iers2trans('ITRF2014', 'ITRF1991', date(2010, 1, 1),
                         27.4, 15.5, -76.8, 4.49, 0, 0, 0.26,
                         0.1, -0.5, -3.3, 0.12, 0, 0, 0.02)
 
-itrf14to90 = iers2trans('ITRF2014', 'ITRF1990', 2010.0,
+itrf14to90 = iers2trans('ITRF2014', 'ITRF1990', date(2010, 1, 1),
                         25.4, 11.5, -92.8, 4.79, 0, 0, 0.26,
                         0.1, -0.5, -3.3, 0.12, 0, 0, 0.02)
 
-itrf14to89 = iers2trans('ITRF2014', 'ITRF1989', 2010.0,
+itrf14to89 = iers2trans('ITRF2014', 'ITRF1989', date(2010, 1, 1),
                         30.4, 35.5, -130.8, 8.19, 0, 0, 0.26,
                         0.1, -0.5, -3.3, 0.12, 0, 0, 0.02)
 
-itrf14to88 = iers2trans('ITRF2014', 'ITRF1988', 2010.0,
+itrf14to88 = iers2trans('ITRF2014', 'ITRF1988', date(2010, 1, 1),
                         25.4, -0.5, -154.8, 11.29, 0.1, 0, 0.26,
                         0.1, -0.5, -3.3, 0.12, 0, 0, 0.02)
 
 # ITRF2008 Parameters
 # link: http://itrf.ign.fr/doc_ITRF/Transfo-ITRF2008_ITRFs.txt
 
-itrf08to05 = iers2trans('ITRF2008', 'ITRF2005', 2000.0,
+itrf08to05 = iers2trans('ITRF2008', 'ITRF2005', date(2000, 1, 1),
                         -2.0, -0.9, -4.7, 0.94, 0, 0, 0,
                         0.3, 0.0, 0.0, 0.0, 0, 0, 0)
 
-itrf08to00 = iers2trans('ITRF2008', 'ITRF2000', 2000.0,
+itrf08to00 = iers2trans('ITRF2008', 'ITRF2000', date(2000, 1, 1),
                         -1.9, -1.7, -10.5, 1.34, 0, 0, 0,
                         0.1, 0.1, -1.8, 0.08, 0, 0, 0)
 
-itrf08to97 = iers2trans('ITRF2008', 'ITRF1997', 2000.0,
+itrf08to97 = iers2trans('ITRF2008', 'ITRF1997', date(2000, 1, 1),
                         4.8, 2.6, -33.2, 2.92, 0, 0, 0.06,
                         0.1, -0.5, -3.2, 0.09, 0, 0, 0.02)
 
-itrf08to96 = iers2trans('ITRF2008', 'ITRF1996', 2000.0,
+itrf08to96 = iers2trans('ITRF2008', 'ITRF1996', date(2000, 1, 1),
                         4.8, 2.6, -33.2, 2.92, 0, 0, 0.06,
                         0.1, -0.5, -3.2, 0.09, 0, 0, 0.02)
 
-itrf08to94 = iers2trans('ITRF2008', 'ITRF1994', 2000.0,
+itrf08to94 = iers2trans('ITRF2008', 'ITRF1994', date(2000, 1, 1),
                         4.8, 2.6, -33.2, 2.92, 0, 0, 0.06,
                         0.1, -0.5, -3.2, 0.09, 0, 0, 0.02)
 
-itrf08to93 = iers2trans('ITRF2008', 'ITRF1993', 2000.0,
+itrf08to93 = iers2trans('ITRF2008', 'ITRF1993', date(2000, 1, 1),
                         -24.0, 2.4, -38.6, 3.41, -1.71, -1.48, -0.30,
                         -2.8, -0.1, -2.4, 0.09, -0.11, -0.19, 0.07)
 
-itrf08to92 = iers2trans('ITRF2008', 'ITRF1992', 2000.0,
+itrf08to92 = iers2trans('ITRF2008', 'ITRF1992', date(2000, 1, 1),
                         12.8, 4.6, -41.2, 2.21, 0, 0, 0.06,
                         0.1, -0.5, -3.2, 0.09, 0, 0, 0.02)
 
-itrf08to91 = iers2trans('ITRF2008', 'ITRF1991', 2000.0,
+itrf08to91 = iers2trans('ITRF2008', 'ITRF1991', date(2000, 1, 1),
                         24.8, 18.6, -47.2, 3.61, 0, 0, 0.06,
                         0.1, -0.5, -3.2, 0.09, 0, 0, 0.02)
 
-itrf08to90 = iers2trans('ITRF2008', 'ITRF1990', 2000.0,
+itrf08to90 = iers2trans('ITRF2008', 'ITRF1990', date(2000, 1, 1),
                         22.8, 14.6, -63.2, 3.91, 0, 0, 0.06,
                         0.1, -0.5, -3.2, 0.09, 0, 0, 0.02)
 
-itrf08to89 = iers2trans('ITRF2008', 'ITRF1989', 2000.0,
+itrf08to89 = iers2trans('ITRF2008', 'ITRF1989', date(2000, 1, 1),
                         27.8, 38.6, -101.2, 7.31, 0, 0, 0.06,
                         0.1, -0.5, -3.2, 0.09, 0, 0, 0.02)
 
-itrf08to88 = iers2trans('ITRF2008', 'ITRF1988', 2000.0,
+itrf08to88 = iers2trans('ITRF2008', 'ITRF1988', date(2000, 1, 1),
                         22.8, 2.6, -125.2, 10.41, 0.10, 0, 0.06,
                         0.1, -0.5, -3.2, 0.09, 0, 0, 0.02)
 
 # ITRF2005 Parameters
 # link: http://itrf.ensg.ign.fr/ITRF_solutions/2005/tp_05-00.php
 
-itrf05to00 = iers2trans('ITRF2005', 'ITRF2000', 2000.0,
+itrf05to00 = iers2trans('ITRF2005', 'ITRF2000', date(2000, 1, 1),
                         0.1, -0.8, -5.8, 0.40, 0, 0, 0,
                         -0.2, 0.1, -1.8, 0.08, 0, 0, 0)
 
@@ -363,38 +320,38 @@ itrf05to00 = iers2trans('ITRF2005', 'ITRF2000', 2000.0,
 # NOTE: This ref lists translations in centimetres. All other ITRF transformations are shown in millimetres.
 # NOTE: All translations and rates of translation shown below have been converted to millimetres.
 
-itrf00to97 = iers2trans('ITRF2000', 'ITRF1997', 1997.0,
+itrf00to97 = iers2trans('ITRF2000', 'ITRF1997', date(1997, 1, 1),
                         6.7, 6.1, -18.5, 1.55, 0, 0, 0,
                         0.0, -0.6, -1.4, 0.01, 0, 0, 0.02)
 
-itrf00to96 = iers2trans('ITRF2000', 'ITRF1996', 1997.0,
+itrf00to96 = iers2trans('ITRF2000', 'ITRF1996', date(1997, 1, 1),
                         6.7, 6.1, -18.5, 1.55, 0, 0, 0,
                         0.0, -0.6, -1.4, 0.01, 0, 0, 0.02)
 
-itrf00to94 = iers2trans('ITRF2000', 'ITRF1994', 1997.0,
+itrf00to94 = iers2trans('ITRF2000', 'ITRF1994', date(1997, 1, 1),
                         6.7, 6.1, -18.5, 1.55, 0, 0, 0,
                         0.0, -0.6, -1.4, 0.01, 0, 0, 0.02)
 
-itrf00to93 = iers2trans('ITRF2000', 'ITRF1993', 1988.0,
+itrf00to93 = iers2trans('ITRF2000', 'ITRF1993', date(1988, 1, 1),
                         12.7, 6.5, -20.9, 1.95, -0.39, 0.80, -1.14,
                         -2.9, -0.2, -0.6, 0.01, -0.11, -0.19, 0.07)
 
-itrf00to92 = iers2trans('ITRF2000', 'ITRF1992', 1988.0,
+itrf00to92 = iers2trans('ITRF2000', 'ITRF1992', date(1988, 1, 1),
                         14.7, 13.5, -13.9, 0.75, 0, 0, -0.18,
                         0.0, -0.6, -1.4, 0.01, 0, 0, 0.02)
 
-itrf00to91 = iers2trans('ITRF2000', 'ITRF1991', 1988.0,
+itrf00to91 = iers2trans('ITRF2000', 'ITRF1991', date(1988, 1, 1),
                         26.7, 27.5, -19.9, 2.15, 0, 0, -0.18,
                         0.0, -0.6, -1.4, 0.01, 0, 0, 0.02)
 
-itrf00to90 = iers2trans('ITRF2000', 'ITRF1990', 1988.0,
+itrf00to90 = iers2trans('ITRF2000', 'ITRF1990', date(1988, 1, 1),
                         14.7, 13.5, -13.9, 0.75, 0, 0, -0.18,
                         0.0, -0.6, -1.4, 0.01, 0, 0, 0.02)
 
-itrf00to89 = iers2trans('ITRF2000', 'ITRF1989', 1988.0,
+itrf00to89 = iers2trans('ITRF2000', 'ITRF1989', date(1988, 1, 1),
                         29.7, 47.5, -73.9, 5.85, 0, 0, -0.18,
                         0.0, -0.6, -1.4, 0.01, 0, 0, 0.02)
 
-itrf00to88 = iers2trans('ITRF2000', 'ITRF1988', 1988.0,
+itrf00to88 = iers2trans('ITRF2000', 'ITRF1988', date(1988, 1, 1),
                         24.7, 11.5, -97.9, 8.95, 0, 0, -0.18,
                         0.0, -0.6, -1.4, 0.01, 0, 0, 0.02)

--- a/geodepy/survey.py
+++ b/geodepy/survey.py
@@ -255,7 +255,7 @@ def fbk2msr(path, cfg_path):
     fbk_project = removeobs(cfg, fbk_project)
     # Reduce observations in setups
     for setup in fbk_project:
-        reduced_obs = reducesetup(setup.observation, strict=False, zerodist=True)
+        reduced_obs = reducesetup(setup.observation, strict=False, zerodist=False)
         setup.observation = reduced_obs
     # Produce Measurement format data from setups
     msr_raw = []

--- a/geodepy/survey.py
+++ b/geodepy/survey.py
@@ -341,9 +341,9 @@ def writestn(file):
             delta_north = shift_list[1]
             delta_up = shift_list[2]
             for pt in ptlist:
-                pt[1] = str('{:.3f}'.format(float(pt[1]) + float(delta_east)))
-                pt[2] = str('{:.3f}'.format(float(pt[2]) + float(delta_north)))
-                pt[3] = str('{:.3f}'.format(float(pt[3]) + float(delta_up)))
+                pt[1] = str('{:.4f}'.format(float(pt[1]) + float(delta_east)))
+                pt[2] = str('{:.4f}'.format(float(pt[2]) + float(delta_north)))
+                pt[3] = str('{:.4f}'.format(float(pt[3]) + float(delta_up)))
 
     # Rename Points as per Config file
     for num, i in enumerate(rename_list):
@@ -367,6 +367,17 @@ def writestn(file):
             if pt[1] == pt_constrain:
                 ptlist[num][0] = 'CCC'
 
+    # Remove Duplicate Station Points
+    cleanlist = []
+    deduplist = []
+    dedupnum = []
+    for num, pt in enumerate(ptlist):
+        if pt[1] not in deduplist:
+            deduplist.append(pt[1])
+            dedupnum.append(num)
+    for num in dedupnum:
+        cleanlist.append(ptlist[num])
+
     # Write header line
     stn = []
     header = ('!#=DNA 3.01 STN    '
@@ -374,20 +385,20 @@ def writestn(file):
               + month + '.'
               + year
               + 'GDA94'.rjust(14)
-              + (str(len(ptlist))).rjust(25))
+              + (str(len(cleanlist))).rjust(25))
     stn.append(header)
 
     # Write line strings in stn format
-    for pt in ptlist:
+    for pt in cleanlist:
         line = (pt[1].ljust(20)  # Pt ID
                 + pt[0]  # Constraint
-                + ' UTM'  # Projection
+                + ' UTM '  # Projection
                 + pt[2].rjust(13)  # Easting
                 + pt[3].rjust(18)  # Northing
                 + pt[4].rjust(16)  # Elevation
-                + 'S56'.rjust(16)  # Hemisphere/Zone input
+                + 'S56'.rjust(15)  # Hemisphere/Zone input
                 + ' '
-                + pt[4])  # Pt Description
+                + pt[5])  # Pt Description
         stn.append(line)
     # Write line strings to file
     fn, ext = os.path.splitext(file)

--- a/geodepy/survey.py
+++ b/geodepy/survey.py
@@ -325,7 +325,6 @@ def writestn(file):
     constrain_list = []
     rename_list = []
     remove_list = []
-    shift_list = []
     for group in cfg_list:
         group_header = group[0].lower()
         if group_header.startswith('constrain'):
@@ -342,9 +341,9 @@ def writestn(file):
             delta_north = shift_list[1]
             delta_up = shift_list[2]
             for pt in ptlist:
-                pt[2] = round(pt[2] + delta_east, 4)
-                pt[3] = round(pt[3] + delta_north, 4)
-                pt[4] = round(pt[4] + delta_up, 4)
+                pt[1] = str('{:.3f}'.format(float(pt[1]) + float(delta_east)))
+                pt[2] = str('{:.3f}'.format(float(pt[2]) + float(delta_north)))
+                pt[3] = str('{:.3f}'.format(float(pt[3]) + float(delta_up)))
 
     # Rename Points as per Config file
     for num, i in enumerate(rename_list):

--- a/geodepy/survey.py
+++ b/geodepy/survey.py
@@ -325,6 +325,7 @@ def writestn(file):
     constrain_list = []
     rename_list = []
     remove_list = []
+    shift_list = []
     for group in cfg_list:
         group_header = group[0].lower()
         if group_header.startswith('constrain'):
@@ -333,6 +334,17 @@ def writestn(file):
             rename_list = group[1:]
         elif group_header.startswith('remove'):
             remove_list = group[1:]
+
+        # Perform Block Shift of Coordinates as Specified in Config
+        elif group_header.startswith('blockshift'):
+            shift_list = group[1:]
+            delta_east = shift_list[0]
+            delta_north = shift_list[1]
+            delta_up = shift_list[2]
+            for pt in ptlist:
+                pt[2] = round(pt[2] + delta_east, 4)
+                pt[3] = round(pt[3] + delta_north, 4)
+                pt[4] = round(pt[4] + delta_up, 4)
 
     # Rename Points as per Config file
     for num, i in enumerate(rename_list):

--- a/geodepy/tests/test_transform.py
+++ b/geodepy/tests/test_transform.py
@@ -1,7 +1,9 @@
 import unittest
 
-from geodepy.transform import geo2grid, grid2geo, llh2xyz, xyz2llh
+from geodepy.transform import geo2grid, grid2geo, llh2xyz, xyz2llh, conform7, conform14
 from geodepy.convert import dms2dd_v, read_dnacoord
+from geodepy.constants import itrf14togda20, gda94to20
+from datetime import date
 import numpy as np
 import os.path
 
@@ -74,6 +76,34 @@ class TestTransforms(unittest.TestCase):
             latcomp, longcomp, psf, grid_conv = grid2geo(coord.zone, coord.easting, coord.northing)
             assert (abs(latcomp - coord.lat) < 5e-9)
             assert (abs(longcomp - coord.long) < 5e-9)
+
+
+    def test_conform7(self):
+        # Replication of tests in GDA2020 Tech Manual v1.2 - Sect 3.1.1
+        alic_gda1994 = (-4052051.7643, 4212836.2017, -2545106.0245)
+        alic_gda2020 = (-4052052.7379, 4212835.9897, -2545104.5898)
+        alic_gda2020_comp = conform7(*alic_gda1994, gda94to20)
+        alic_gda1994_comp = conform7(*alic_gda2020, -gda94to20)
+        assert (abs(alic_gda2020_comp[0] - alic_gda2020[0]) < 5e-5)
+        assert (abs(alic_gda2020_comp[1] - alic_gda2020[1]) < 5e-5)
+        assert (abs(alic_gda2020_comp[2] - alic_gda2020[2]) < 5e-5)
+        assert (abs(alic_gda1994_comp[0] - alic_gda1994[0]) < 5e-5)
+        assert (abs(alic_gda1994_comp[1] - alic_gda1994[1]) < 5e-5)
+        assert (abs(alic_gda1994_comp[2] - alic_gda1994[2]) < 5e-5)
+
+
+    def test_conform14(self):
+        # Replication of tests in GDA2020 Tech Manual v1.2 - Sect 3.3.1
+        alic_gda2020 = (-4052052.7373, 4212835.9835, -2545104.5867)
+        alic_itrf14at2018 = (-4052052.6588, 4212835.9938, -2545104.6946)
+        alic_itrf14at2018_comp = conform14(*alic_gda2020, date(2018, 1, 1), -itrf14togda20)
+        alic_gda2020_comp = conform14(*alic_itrf14at2018, date(2018, 1, 1), itrf14togda20)
+        assert (abs(alic_itrf14at2018_comp[0] - alic_itrf14at2018[0]) < 5e-5)
+        assert (abs(alic_itrf14at2018_comp[1] - alic_itrf14at2018[1]) < 5e-5)
+        assert (abs(alic_itrf14at2018_comp[2] - alic_itrf14at2018[2]) < 5e-5)
+        assert (abs(alic_gda2020_comp[0] - alic_gda2020[0]) < 5e-5)
+        assert (abs(alic_gda2020_comp[1] - alic_gda2020[1]) < 5e-5)
+        assert (abs(alic_gda2020_comp[2] - alic_gda2020[2]) < 5e-5)
 
 
 if __name__ == '__main__':

--- a/geodepy/transform.py
+++ b/geodepy/transform.py
@@ -11,6 +11,7 @@ Ref2: http://www.mygeodesy.id.au/documents/Karney-Krueger%20equations.pdf
 
 import os
 import csv
+import datetime
 from math import sqrt, log, degrees, radians, sin, cos, tan, sinh, cosh, atan, atan2, modf
 import numpy as np
 from geodepy.constants import grs80, utm, Transformation
@@ -473,7 +474,7 @@ def conform7(x, y, z, trans):
     :param x: Cartesian X (m)
     :param y: Cartesian Y (m)
     :param z: Cartesian Z (m)
-    :param trans: Transformation Object
+    :param trans: Transformation Object (note: this function ignores all time-dependent variables)
     :return: Transformed X, Y, Z Cartesian Co-ordinates
     """
     if type(trans) != Transformation:
@@ -512,22 +513,19 @@ def conform14(x, y, z, to_epoch, trans):
     :param x: Cartesian X (m)
     :param y: Cartesian Y (m)
     :param z: Cartesian Z (m)
-    :param to_epoch: Epoch co-ordinate transformation is performed at in YYYY.DOY notation
+    :param to_epoch: Epoch co-ordinate transformation is performed at (datetime.date Object)
     :param trans: Transformation Object
     :return: Cartesian X, Y, Z co-ordinates transformed using Transformation parameters at desired epoch
     """
     if type(trans) != Transformation:
         raise ValueError('trans must be a Transformation Object')
-    # Convert YYYY.DOY to Decimal Year
-    to_doy, to_year = modf(to_epoch)
-    ref_doy, ref_year = modf(trans.ref_epoch)
-    to_epoch = to_year + ((to_doy - 0.0005) / 0.36525)
-    ref_epoch = ref_year + (ref_doy / 0.36525)
-    # Perform Conformal 7 Parameter Transformation
-    # debug - output Transformation Object
-    timetrans = (trans + (to_epoch - ref_epoch))
+    if type(to_epoch) != datetime.date:
+        raise ValueError('to_epoch must be a datetime.date Object')
+    # Calculate 7 Parameters from 14 Parameter Transformation Object
+    timetrans = trans + to_epoch
+    # Perform Transformation
     xtrans, ytrans, ztrans = conform7(x, y, z, timetrans)
-    return xtrans, ytrans, ztrans  # , timetrans
+    return xtrans, ytrans, ztrans
 
 
 def grid2geoio():


### PR DESCRIPTION
- Changes the epoch reference in Transformation Objects (used in time-dependent conformal transformations) to use datetime.date objects. 
- Modifies functions using these Transformation Objects, namely conform14, to handle these changes.
- Adds test coverage of conform14 and conform7 using examples from the GDA2020 Tech Manual.
- Includes several modifications to the survey module.