### PR TITLE
Issue #82: Unit Tests for statistics.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 __pycache__
 
 # Compiled python modules.
@@ -6,6 +5,7 @@ __pycache__
 
 # Setuptools distribution folder.
 /dist/
+env
 
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info
@@ -13,8 +13,8 @@ __pycache__
 # Ignore test-related files
 /coverage.data
 /coverage/
-.coverage
-htmlcov/
+
+# IDEs
 .vscode
-env
+.idea
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ __pycache__
 # Ignore test-related files
 /coverage.data
 /coverage/
+.coverage
+htmlcov/
+.vscode
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+env
 .idea
 __pycache__
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-env
 .idea
 __pycache__
 
@@ -17,4 +16,5 @@ __pycache__
 .coverage
 htmlcov/
 .vscode
+env
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ NumPy
 
 ### Testing
 
-Run: `python -m unittest discover geodepy/tests/`
+Run: `python -m unittest discover geodepy/tests/ --verbose`
 
 ### Tutorials
 

--- a/geodepy/statistics.py
+++ b/geodepy/statistics.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import sys
+sys.path.append('./env/lib/python3.7/site-packages')
 from math import radians, sin, cos, sqrt, atan2, degrees
 import numpy as np
 

--- a/geodepy/statistics.py
+++ b/geodepy/statistics.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-sys.path.append('./env/lib/python3.7/site-packages')
 from math import radians, sin, cos, sqrt, atan2, degrees
 import numpy as np
 

--- a/geodepy/statistics.py
+++ b/geodepy/statistics.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-import sys
-sys.path.append('./env/lib/python3.7/site-packages')
 from math import radians, sin, cos, sqrt, atan2, degrees
 import numpy as np
 

--- a/geodepy/tests/test_statistics.py
+++ b/geodepy/tests/test_statistics.py
@@ -1,6 +1,3 @@
-import sys
-sys.path.append("../geodepy")
-
 import unittest
 from geodepy import statistics
 from geodepy.statistics import np

--- a/geodepy/tests/test_statistics.py
+++ b/geodepy/tests/test_statistics.py
@@ -1,0 +1,22 @@
+def test_rotation_matrix():
+    pass
+
+
+def test_vcv_cart2local():
+    pass
+
+
+def test_vcv_local2cart2():
+    pass
+
+
+def test_error_ellipse():
+    pass
+
+
+def test_circ_hz_pu():
+    pass
+
+
+def test_k_val95():
+    pass

--- a/geodepy/tests/test_statistics.py
+++ b/geodepy/tests/test_statistics.py
@@ -1,22 +1,48 @@
-def test_rotation_matrix():
-    pass
+import sys
+sys.path.append("../geodepy")
+
+import unittest
+from geodepy import statistics
+from geodepy.statistics import np
+from math import radians, sin, cos, sqrt, atan2, degrees
 
 
-def test_vcv_cart2local():
-    pass
+class TestStatistics(unittest.TestCase):
+    def test_rotation_matrix(self):
+        
+        lat = 19.4792
+        lon =  70.6931
+
+        expected_result = np.array([
+            [-0.94376114, -0.11025276, 0.31170376],
+            [0.33062805, -0.31471096, 0.88974272],
+            [0.0       ,  0.94276261,  0.33346463]
+        ])
+        
+        result =  statistics.rotation_matrix(lat, lon)
+        
+        np.array_equal(result, expected_result)
+        self.assertEqual(type(result), np.ndarray)
 
 
-def test_vcv_local2cart2():
-    pass
+    def test_vcv_cart2local(self):
+        pass
 
 
-def test_error_ellipse():
-    pass
+    def test_vcv_local2cart2(self):
+        pass
 
 
-def test_circ_hz_pu():
-    pass
+    def test_error_ellipse(self):
+        pass
 
 
-def test_k_val95():
-    pass
+    def test_circ_hz_pu(self):
+        pass
+
+
+    def test_k_val95(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/geodepy/tests/test_statistics.py
+++ b/geodepy/tests/test_statistics.py
@@ -4,64 +4,62 @@ sys.path.append("../geodepy")
 import unittest
 from geodepy import statistics
 from geodepy.statistics import np
-from math import radians, sin, cos, sqrt, atan2, degrees
 
 
 class TestStatistics(unittest.TestCase):
     def test_rotation_matrix(self):
-        
         lat = 19.4792
-        lon =  70.6931
+        lon = 70.6931
 
         expected_result = np.array([
             [-0.94376114, -0.11025276, 0.31170376],
             [0.33062805, -0.31471096, 0.88974272],
-            [0.0       ,  0.94276261,  0.33346463]
+            [0.0,  0.94276261,  0.33346463],
         ])
-        
-        result =  statistics.rotation_matrix(lat, lon)
-        
+
+        result = statistics.rotation_matrix(lat, lon)
+
         np.array_equal(expected_result, result)
         self.assertEqual(type(expected_result), type(result))
 
-
-    def test_vcv_cart2local_3X3(self):
-        
-        lat = 19.4792
-        lon = 70.6931
+    def test_vcv_cart2local_and_vcv_local2cart2_3X3(self):
+        lat = 19.4792453
+        lon = 70.69315634
         v_cart = np.array([
             [0.0, 0.0, 0.0],
             [0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0]
+            [0.0, 0.0, 0.0],
         ])
-
         expected_result = np.array([
-            [ 0.10931491, -0.10405227,  0.2941739 ],
-            [-0.10405227,  1.87664567,  0.34874419],
-            [ 0.2941739,   0.34874419,  1.01403942]
+            [0., 0., 0.],
+            [0., 0., 0.],
+            [0., 0., 0.],
         ])
-        
-        result = statistics.vcv_cart2local(v_cart, lat, lon)
 
-        np.array_equal(expected_result, result)
-        self.assertEqual(type(expected_result), type(result))
+        result_cart2local = statistics.vcv_cart2local(v_cart, lat, lon)
+        result_local2cart = statistics.vcv_local2cart(v_cart, lat, lon)
 
-    def test_vcv_cart2local_3X2(self):
-        
+        np.testing.assert_array_equal(expected_result, result_cart2local)
+        np.testing.assert_array_equal(expected_result, result_local2cart)
+        self.assertEqual(type(expected_result), type(result_cart2local))
+        self.assertEqual(type(expected_result), type(result_local2cart))
+
+    def test_vcv_cart2local_and_vcv_local2cart2_3X2(self):
         lat = 0.0
         lon = 0.0
         v_cart = np.array([
             [0.0, 0.0],
             [0.0, 0.0],
-            [0.0, 0.0]
+            [0.0, 0.0],
         ])
 
         with self.assertRaises(SystemExit):
             statistics.vcv_cart2local(v_cart, lat, lon)
 
+        with self.assertRaises(SystemExit):
+            statistics.vcv_local2cart(v_cart, lat, lon)
 
-    def test_vcv_cart2local_2X3(self):
-        
+    def test_vcv_cart2local_and_vcv_local2cart2_2X3(self):
         lat = 0.0
         lon = 0.0
         v_cart = np.array([
@@ -72,43 +70,83 @@ class TestStatistics(unittest.TestCase):
         with self.assertRaises(SystemExit):
             statistics.vcv_cart2local(v_cart, lat, lon)
 
+        with self.assertRaises(SystemExit):
+            statistics.vcv_local2cart(v_cart, lat, lon)
 
-    def test_vcv_cart2local_1X3(self):
-        
+    def test_vcv_cart2local_and_vcv_local2cart2_1X3(self):
         lat = 0.0
         lon = 0.0
         v_cart = np.array([
             [0.0],
             [0.0],
-            [0.0]
+            [0.0],
         ])
-
         expected_result = np.array([
-            [0.0, 0.0, 0.0,],
-            [0.0, 0.0, 0.0,],
-            [0.0, 0.0, 0.0,]
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
         ])
-        
-        result = statistics.vcv_cart2local(v_cart, lat, lon)
-        
-        np.array_equal(expected_result, result)
-        self.assertEqual(type(expected_result), type(result))
 
+        result_cart2local = statistics.vcv_cart2local(v_cart, lat, lon)
+        result_local2cart = statistics.vcv_local2cart(v_cart, lat, lon)
 
-    def test_vcv_local2cart2(self):
-        pass
-
+        np.testing.assert_array_equal(expected_result, result_cart2local)
+        np.testing.assert_array_equal(expected_result, result_local2cart)
+        self.assertEqual(type(expected_result), type(result_cart2local))
+        self.assertEqual(type(expected_result), type(result_local2cart))
 
     def test_error_ellipse(self):
-        pass
+        vcv = np.array([
+            [90, 0, 0],
+            [0, 90, 0],
+            [0, 0, 90],
+        ])
+        expected_result = (9.486832980505138, 9.486832980505138, 90.0)
 
+        result = statistics.error_ellipse(vcv)
+
+        self.assertEqual(expected_result, result)
+        self.assertEqual(type(expected_result), type(result))
 
     def test_circ_hz_pu(self):
-        pass
+        a = 1
+        b = 0
 
+        expeted_result = 1.96079
 
-    def test_k_val95(self):
-        pass
+        result = statistics.circ_hz_pu(a, b)
+        self.assertEqual(expeted_result, result)
+
+    def test_k_val95_typeError(self):
+        dof = [[], {}, ""]
+
+        for item in dof:
+            with self.assertRaises(TypeError):
+                statistics.k_val95(dof)
+
+    def test_k_val95_less_1(self):
+        dof = -1
+
+        expected_result = statistics.ttable_p95[0]
+
+        result = statistics.k_val95(dof)
+        self.assertEqual(expected_result, result)
+
+    def test_k_val95_greater_120(self):
+        dof = 121
+
+        expected_result = 1.96
+
+        result = statistics.k_val95(dof)
+        self.assertEqual(expected_result, result)
+
+    def test_k_val95_between_1_and_120(self):
+        dof = 100
+
+        expected_result = statistics.ttable_p95[dof - 1]
+
+        result = statistics.k_val95(dof)
+        self.assertEqual(expected_result, result)
 
 
 if __name__ == '__main__':

--- a/geodepy/tests/test_statistics.py
+++ b/geodepy/tests/test_statistics.py
@@ -21,12 +21,78 @@ class TestStatistics(unittest.TestCase):
         
         result =  statistics.rotation_matrix(lat, lon)
         
-        np.array_equal(result, expected_result)
-        self.assertEqual(type(result), np.ndarray)
+        np.array_equal(expected_result, result)
+        self.assertEqual(type(expected_result), type(result))
 
 
-    def test_vcv_cart2local(self):
-        pass
+    def test_vcv_cart2local_3X3(self):
+        
+        lat = 19.4792
+        lon = 70.6931
+        v_cart = np.array([
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0]
+        ])
+
+        expected_result = np.array([
+            [ 0.10931491, -0.10405227,  0.2941739 ],
+            [-0.10405227,  1.87664567,  0.34874419],
+            [ 0.2941739,   0.34874419,  1.01403942]
+        ])
+        
+        result = statistics.vcv_cart2local(v_cart, lat, lon)
+
+        np.array_equal(expected_result, result)
+        self.assertEqual(type(expected_result), type(result))
+
+    def test_vcv_cart2local_3X2(self):
+        
+        lat = 0.0
+        lon = 0.0
+        v_cart = np.array([
+            [0.0, 0.0],
+            [0.0, 0.0],
+            [0.0, 0.0]
+        ])
+
+        with self.assertRaises(SystemExit):
+            statistics.vcv_cart2local(v_cart, lat, lon)
+
+
+    def test_vcv_cart2local_2X3(self):
+        
+        lat = 0.0
+        lon = 0.0
+        v_cart = np.array([
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ])
+
+        with self.assertRaises(SystemExit):
+            statistics.vcv_cart2local(v_cart, lat, lon)
+
+
+    def test_vcv_cart2local_1X3(self):
+        
+        lat = 0.0
+        lon = 0.0
+        v_cart = np.array([
+            [0.0],
+            [0.0],
+            [0.0]
+        ])
+
+        expected_result = np.array([
+            [0.0, 0.0, 0.0,],
+            [0.0, 0.0, 0.0,],
+            [0.0, 0.0, 0.0,]
+        ])
+        
+        result = statistics.vcv_cart2local(v_cart, lat, lon)
+        
+        np.array_equal(expected_result, result)
+        self.assertEqual(type(expected_result), type(result))
 
 
     def test_vcv_local2cart2(self):
@@ -43,6 +109,7 @@ class TestStatistics(unittest.TestCase):
 
     def test_k_val95(self):
         pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Writing tests for the `statistics.py` and the methods:
- [x] rotation_matrix()
- [x] vcv_cart2local()
- [x] vcv_local2cart2()
- [x] error_ellipse()
- [x] circ_hz_pu()
- [x] k_val95()

### How to Test
1. Create a virtual env `python3 -m venv env`
2. Enter the virtual environment `source env/bin/activate`
3. Upgrade pip `pip install --upgrade pip`
4. Install `coverage` -> `pip install coverage`
5. Install `numpy` -> `pip install numpy`
6. Run the test -> `coverage run geodepy/tests/test_statistics.py`
7. Run the report -> `coverage report ../geodepy/geodepy/statistics.py`
8. Run `coverage html ../geodepy/geodepy/statistics.py`
9. Open in Browser `open htmlcov/index.html `