### PR TITLE
Minor refactoring for webinar

### DIFF
--- a/geodepy/constants.py
+++ b/geodepy/constants.py
@@ -166,8 +166,8 @@ def iers2trans(itrf_from, itrf_to, ref_epoch, tx, ty, tz, sc, rx, ry, rz, d_tx, 
 
 # GDA1994 to GDA2020 Transformation Parameters from GDA2020 Tech Manual v1.2
 
-gda94to20 = Transformation('GDA1994', 'GDA2020', 0,
-                           0.06155, -0.01087, -0.04019, -0.009994, -0.0394924, -0.0327221, -0.0328979)
+gda94_to_gda2020 = Transformation('GDA1994', 'GDA2020', 0,
+                                  0.06155, -0.01087, -0.04019, -0.009994, -0.0394924, -0.0327221, -0.0328979)
 
 # ITRF2014 to GDA2020 (Australian Plate Motion Model) Transformation Parameters from GDA2020 Tech Manual v1.2. The
 # model was derived using 109 ARGN and AuScope GNSS CORS which were used to define the RVS.

--- a/geodepy/tests/test_transform.py
+++ b/geodepy/tests/test_transform.py
@@ -3,7 +3,7 @@ import unittest
 from geodepy.transform import (conform7,
                                conform14,
                                atrftogda2020,
-                               gda2020toatrf,
+                               gda2020_to_atrf2014,
                                mga94to2020,
                                mga2020to94)
 from geodepy.convert import DMSAngle, hp2dec_v, geo2grid, grid2geo, xyz2llh, \
@@ -167,7 +167,7 @@ class TestTransforms(unittest.TestCase):
     def test_atrftogda2020(self):
         alic_gda2020 = (-4052052.7373, 4212835.9835, -2545104.5867)
         alic_itrf14at2018 = (-4052052.6588, 4212835.9938, -2545104.6946)
-        alic_itrf14at2018_comp = gda2020toatrf(*alic_gda2020, date(2018, 1, 1))
+        alic_itrf14at2018_comp = gda2020_to_atrf2014(*alic_gda2020, date(2018, 1, 1))
         alic_gda2020_comp = atrftogda2020(*alic_itrf14at2018, date(2018, 1, 1))
         assert (abs(alic_itrf14at2018_comp[0] - alic_itrf14at2018[0]) < 5e-5)
         assert (abs(alic_itrf14at2018_comp[1] - alic_itrf14at2018[1]) < 5e-5)

--- a/geodepy/tests/test_transform.py
+++ b/geodepy/tests/test_transform.py
@@ -4,7 +4,7 @@ from geodepy.transform import (conform7,
                                conform14,
                                atrf2014_to_gda2020,
                                gda2020_to_atrf2014,
-                               mga94to2020,
+                               mga94_to_mga2020,
                                mga2020_to_mga94)
 from geodepy.convert import DMSAngle, hp2dec_v, geo2grid, grid2geo, xyz2llh, \
     llh2xyz
@@ -176,17 +176,17 @@ class TestTransforms(unittest.TestCase):
         assert (abs(alic_gda2020_comp[1] - alic_gda2020[1]) < 5e-5)
         assert (abs(alic_gda2020_comp[2] - alic_gda2020[2]) < 5e-5)
 
-    def test_mga94to2020(self):
+    def test_mga94_to_mga2020(self):
         alic_mga94 = (53, 386352.3979, 7381850.7689, 603.3466)
         alic_mga20 = (53, 386353.2343, 7381852.2986, 603.2489)
         # Test with no ellipsoid height supplied
-        alic_mga20_noellht_comp = mga94to2020(alic_mga94[0], alic_mga94[1], alic_mga94[2])
+        alic_mga20_noellht_comp = mga94_to_mga2020(alic_mga94[0], alic_mga94[1], alic_mga94[2])
         assert ((alic_mga20_noellht_comp[0] - alic_mga20[0]) == 0)
         assert (abs(alic_mga20_noellht_comp[1] - alic_mga20[1]) < 5e-5)
         assert (abs(alic_mga20_noellht_comp[2] - alic_mga20[2]) < 5e-5)
         assert (alic_mga20_noellht_comp[3] == 0)
         # Test with ellipsoid height supplied
-        alic_mga20_ellht_comp = mga94to2020(alic_mga94[0], alic_mga94[1], alic_mga94[2], alic_mga94[3])
+        alic_mga20_ellht_comp = mga94_to_mga2020(alic_mga94[0], alic_mga94[1], alic_mga94[2], alic_mga94[3])
         assert ((alic_mga20_ellht_comp[0] - alic_mga20[0]) == 0)
         assert (abs(alic_mga20_ellht_comp[1] - alic_mga20[1]) < 5e-5)
         assert (abs(alic_mga20_ellht_comp[2] - alic_mga20[2]) < 5e-5)

--- a/geodepy/tests/test_transform.py
+++ b/geodepy/tests/test_transform.py
@@ -5,7 +5,7 @@ from geodepy.transform import (conform7,
                                atrf2014_to_gda2020,
                                gda2020_to_atrf2014,
                                mga94to2020,
-                               mga2020to94)
+                               mga2020_to_mga94)
 from geodepy.convert import DMSAngle, hp2dec_v, geo2grid, grid2geo, xyz2llh, \
     llh2xyz
 from geodepy.constants import itrf14togda20, gda94_to_gda2020
@@ -192,17 +192,17 @@ class TestTransforms(unittest.TestCase):
         assert (abs(alic_mga20_ellht_comp[2] - alic_mga20[2]) < 5e-5)
         assert (abs(alic_mga20_ellht_comp[3] - alic_mga20[3]) < 5e-5)
 
-    def test_mga2020to94(self):
+    def test_mga2020_to_mga94(self):
         alic_mga94 = (53, 386352.3979, 7381850.7689, 603.3466)
         alic_mga20 = (53, 386353.2343, 7381852.2986, 603.2489)
         # Test with no ellipsoid height supplied
-        alic_mga94_noellht_comp = mga2020to94(alic_mga20[0], alic_mga20[1], alic_mga20[2])
+        alic_mga94_noellht_comp = mga2020_to_mga94(alic_mga20[0], alic_mga20[1], alic_mga20[2])
         assert ((alic_mga94_noellht_comp[0] - alic_mga94[0]) == 0)
         assert (abs(alic_mga94_noellht_comp[1] - alic_mga94[1]) < 5e-5)
         assert (abs(alic_mga94_noellht_comp[2] - alic_mga94[2]) < 5e-5)
         assert (alic_mga94_noellht_comp[3] == 0)
         # Test with ellipsoid height supplied
-        alic_mga94_ellht_comp = mga2020to94(alic_mga20[0], alic_mga20[1], alic_mga20[2], alic_mga20[3])
+        alic_mga94_ellht_comp = mga2020_to_mga94(alic_mga20[0], alic_mga20[1], alic_mga20[2], alic_mga20[3])
         assert ((alic_mga94_ellht_comp[0] - alic_mga94[0]) == 0)
         assert (abs(alic_mga94_ellht_comp[1] - alic_mga94[1]) < 5e-5)
         assert (abs(alic_mga94_ellht_comp[2] - alic_mga94[2]) < 5e-5)

--- a/geodepy/tests/test_transform.py
+++ b/geodepy/tests/test_transform.py
@@ -8,7 +8,7 @@ from geodepy.transform import (conform7,
                                mga2020to94)
 from geodepy.convert import DMSAngle, hp2dec_v, geo2grid, grid2geo, xyz2llh, \
     llh2xyz
-from geodepy.constants import itrf14togda20, gda94to20
+from geodepy.constants import itrf14togda20, gda94_to_gda2020
 from geodepy.fileio import read_dnacoord
 from datetime import date
 import numpy as np
@@ -142,8 +142,8 @@ class TestTransforms(unittest.TestCase):
         # Replication of tests in GDA2020 Tech Manual v1.2 - Sect 3.1.1
         alic_gda1994 = (-4052051.7643, 4212836.2017, -2545106.0245)
         alic_gda2020 = (-4052052.7379, 4212835.9897, -2545104.5898)
-        alic_gda2020_comp = conform7(*alic_gda1994, gda94to20)
-        alic_gda1994_comp = conform7(*alic_gda2020, -gda94to20)
+        alic_gda2020_comp = conform7(*alic_gda1994, gda94_to_gda2020)
+        alic_gda1994_comp = conform7(*alic_gda2020, -gda94_to_gda2020)
         assert (abs(alic_gda2020_comp[0] - alic_gda2020[0]) < 5e-5)
         assert (abs(alic_gda2020_comp[1] - alic_gda2020[1]) < 5e-5)
         assert (abs(alic_gda2020_comp[2] - alic_gda2020[2]) < 5e-5)

--- a/geodepy/tests/test_transform.py
+++ b/geodepy/tests/test_transform.py
@@ -2,7 +2,7 @@ import unittest
 
 from geodepy.transform import (conform7,
                                conform14,
-                               atrftogda2020,
+                               atrf2014_to_gda2020,
                                gda2020_to_atrf2014,
                                mga94to2020,
                                mga2020to94)
@@ -164,11 +164,11 @@ class TestTransforms(unittest.TestCase):
         assert (abs(alic_gda2020_comp[1] - alic_gda2020[1]) < 5e-5)
         assert (abs(alic_gda2020_comp[2] - alic_gda2020[2]) < 5e-5)
 
-    def test_atrftogda2020(self):
+    def test_atrf2014_to_gda2020(self):
         alic_gda2020 = (-4052052.7373, 4212835.9835, -2545104.5867)
         alic_itrf14at2018 = (-4052052.6588, 4212835.9938, -2545104.6946)
         alic_itrf14at2018_comp = gda2020_to_atrf2014(*alic_gda2020, date(2018, 1, 1))
-        alic_gda2020_comp = atrftogda2020(*alic_itrf14at2018, date(2018, 1, 1))
+        alic_gda2020_comp = atrf2014_to_gda2020(*alic_itrf14at2018, date(2018, 1, 1))
         assert (abs(alic_itrf14at2018_comp[0] - alic_itrf14at2018[0]) < 5e-5)
         assert (abs(alic_itrf14at2018_comp[1] - alic_itrf14at2018[1]) < 5e-5)
         assert (abs(alic_itrf14at2018_comp[2] - alic_itrf14at2018[2]) < 5e-5)

--- a/geodepy/transform.py
+++ b/geodepy/transform.py
@@ -81,7 +81,7 @@ def conform14(x, y, z, to_epoch, trans):
     return xtrans, ytrans, ztrans
 
 
-def mga94to2020(zone, east, north, ell_ht=False):
+def mga94_to_mga2020(zone, east, north, ell_ht=False):
     """
     Performs conformal transformation of Map Grid of Australia 1994 to Map Grid of Australia 2020 Coordinates
     using the GDA2020 Tech Manual v1.2 7 parameter similarity transformation parameters

--- a/geodepy/transform.py
+++ b/geodepy/transform.py
@@ -142,7 +142,7 @@ def atrftogda2020(x, y, z, epoch_from):
     return conform14(x, y, z, epoch_from, atrf_gda2020)
 
 
-def gda2020toatrf(x, y, z, epoch_to):
+def gda2020_to_atrf2014(x, y, z, epoch_to):
     """
     Transforms Cartesian (x, y, z) Coordinates in terms of Geocentric Datum of Australia 2020
     (GDA2020 - reference epoch 2020.0) to coordinates in terms of the Australian Terrestrial Reference Frame (ATRF) at

--- a/geodepy/transform.py
+++ b/geodepy/transform.py
@@ -15,7 +15,7 @@ import datetime
 from math import radians
 import numpy as np
 from geodepy.constants import Transformation, atrf_gda2020,\
-    gda94to20
+    gda94_to_gda2020
 from geodepy.convert import hp2dec, geo2grid, \
     grid2geo, xyz2llh, llh2xyz
 
@@ -97,7 +97,7 @@ def mga94to2020(zone, east, north, ell_ht=False):
     else:
         ell_ht_in = ell_ht
     x94, y94, z94 = llh2xyz(lat, lon, ell_ht_in)
-    x20, y20, z20 = conform7(x94, y94, z94, gda94to20)
+    x20, y20, z20 = conform7(x94, y94, z94, gda94_to_gda2020)
     lat, lon, ell_ht_out = xyz2llh(x20, y20, z20)
     if ell_ht is False:
         ell_ht_out = 0
@@ -121,7 +121,7 @@ def mga2020to94(zone, east, north, ell_ht=False):
     else:
         ell_ht_in = ell_ht
     x94, y94, z94 = llh2xyz(lat, lon, ell_ht_in)
-    x20, y20, z20 = conform7(x94, y94, z94, -gda94to20)
+    x20, y20, z20 = conform7(x94, y94, z94, -gda94_to_gda2020)
     lat, lon, ell_ht_out = xyz2llh(x20, y20, z20)
     if ell_ht is False:
         ell_ht_out = 0

--- a/geodepy/transform.py
+++ b/geodepy/transform.py
@@ -129,7 +129,7 @@ def mga2020to94(zone, east, north, ell_ht=False):
     return zone20, east20, north20, round(ell_ht_out, 4)
 
 
-def atrftogda2020(x, y, z, epoch_from):
+def atrf2014_to_gda2020(x, y, z, epoch_from):
     """
     Transforms Cartesian (x, y, z) Coordinates in terms of the Australian Terrestrial Reference Frame (ATRF) at
     a specified epoch to coordinates in terms of Geocentric Datum of Australia 2020 (GDA2020 - reference epoch 2020.0)

--- a/geodepy/transform.py
+++ b/geodepy/transform.py
@@ -105,7 +105,7 @@ def mga94to2020(zone, east, north, ell_ht=False):
     return zone20, east20, north20, round(ell_ht_out, 4)
 
 
-def mga2020to94(zone, east, north, ell_ht=False):
+def mga2020_to_mga94(zone, east, north, ell_ht=False):
     """
     Performs conformal transformation of Map Grid of Australia 2020 to Map Grid of Australia 1994 Coordinates
     using the reverse form of the GDA2020 Tech Manual v1.2 7 parameter similarity transformation parameters


### PR DESCRIPTION
The functions that are being used in the webinar today (and a couple of others) have been renamed use the full datum/reference frame name, e.g., gda2020toatrf is now gda2020_to_atrf2014, and mga94to2020 is now mga94_to_mga2020