### PR TITLE
Change GDAL import in height.py

### DIFF
--- a/geodepy/height.py
+++ b/geodepy/height.py
@@ -9,7 +9,7 @@
 # Import dependencies 
 import geodepy.constants as cons
 import geodepy.geodesy as gg
-import gdal
+from osgeo import gdal
 import numpy as np
 from scipy.interpolate import griddata
 import math as m


### PR DESCRIPTION
Hi,

The way GDAL is imported has changed since GDAL 3.2

`import gdal`

is now deprecated and has been replaced with

`from osgeo import gdal`

R